### PR TITLE
Fix various compile errors

### DIFF
--- a/lib/dogma/src/enums/iri_error.rs
+++ b/lib/dogma/src/enums/iri_error.rs
@@ -4,7 +4,7 @@
 extern crate std;
 
 #[allow(unused)]
-use crate::prelude::{fmt, String};
+use crate::prelude::{fmt, format, String};
 
 pub type IriResult<T> = core::result::Result<T, IriError>;
 

--- a/lib/dogma/src/prelude.rs
+++ b/lib/dogma/src/prelude.rs
@@ -11,14 +11,19 @@ extern crate alloc;
 #[cfg(feature = "std")]
 use std as alloc;
 
+#[cfg(feature = "std")]
+pub use std::collections::{HashMap, HashSet};
+
 pub use alloc::{
     borrow::{self, Cow, ToOwned},
-    collections::{self, BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque},
-    fmt,
-    hash::{self, Hash, Hasher},
+    collections::{self, BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+    fmt, format,
     str::{self, FromStr},
     string::{self, String, ToString},
     vec::{self, IntoIter, Vec},
 };
 
-pub use core::result::Result;
+pub use core::{
+    hash::{self, Hash, Hasher},
+    result::Result,
+};

--- a/lib/dogma/src/traits/collection.rs
+++ b/lib/dogma/src/traits/collection.rs
@@ -1,8 +1,9 @@
 // This is free and unencumbered software released into the public domain.
 
-use crate::prelude::{
-    BTreeMap, BTreeSet, BinaryHeap, Hash, HashMap, HashSet, LinkedList, Vec, VecDeque,
-};
+use crate::prelude::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, Vec, VecDeque};
+
+#[cfg(feature = "std")]
+use crate::prelude::{Hash, HashMap, HashSet};
 
 /// A trait for collections of items.
 pub trait Collection {
@@ -127,6 +128,7 @@ impl<K: Ord, V> Collection for BTreeMap<K, V> {
 }
 
 // Implementation for `HashSet<T>`
+#[cfg(feature = "std")]
 impl<T: Eq + Hash> Collection for HashSet<T> {
     type Item = T;
 
@@ -140,6 +142,7 @@ impl<T: Eq + Hash> Collection for HashSet<T> {
 }
 
 // Implementation for `HashMap<K, V>`
+#[cfg(feature = "std")]
 impl<K: Eq + Hash, V> Collection for HashMap<K, V> {
     type Item = (K, V);
 

--- a/lib/dogma/src/traits/collection_mut.rs
+++ b/lib/dogma/src/traits/collection_mut.rs
@@ -1,9 +1,10 @@
 // This is free and unencumbered software released into the public domain.
 
 use super::Collection;
-use crate::prelude::{
-    BTreeMap, BTreeSet, BinaryHeap, Hash, HashMap, HashSet, LinkedList, Vec, VecDeque,
-};
+use crate::prelude::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, Vec, VecDeque};
+
+#[cfg(feature = "std")]
+use crate::prelude::{Hash, HashMap, HashSet};
 
 /// A trait for collections of items.
 pub trait CollectionMut: Collection {
@@ -53,6 +54,7 @@ impl<K: Ord, V> CollectionMut for BTreeMap<K, V> {
 }
 
 // Implementation for `HashSet<T>`
+#[cfg(feature = "std")]
 impl<T: Eq + Hash> CollectionMut for HashSet<T> {
     fn clear(&mut self) {
         self.clear()
@@ -60,6 +62,7 @@ impl<T: Eq + Hash> CollectionMut for HashSet<T> {
 }
 
 // Implementation for `HashMap<K, V>`
+#[cfg(feature = "std")]
 impl<K: Eq + Hash, V> CollectionMut for HashMap<K, V> {
     fn clear(&mut self) {
         self.clear()


### PR DESCRIPTION
This PR fixes various compile errors, mainly all errors that occurs when executing:
```
cargo check --release --no-default-features
```
```
cargo check --release --all-features
```
```
cargo check --release --no-default-features --features "traits"
```

@race-of-sloths include